### PR TITLE
Remove shebang and treat # as a comment character

### DIFF
--- a/Openclaw一键安装.md
+++ b/Openclaw一键安装.md
@@ -17,6 +17,7 @@
 
 ```bash
 set -euo pipefail
+setopt INTERACTIVE_COMMENTS
 
 if [[ ! -t 0 || ! -t 1 ]]; then
   echo "请在交互式终端中运行（OAuth 需要浏览器 + 终端交互）。"

--- a/Openclaw一键安装.md
+++ b/Openclaw一键安装.md
@@ -16,7 +16,6 @@
 ## 一键脚本（推荐，直接粘贴执行）
 
 ```bash
-#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ ! -t 0 || ! -t 1 ]]; then


### PR DESCRIPTION
When you paste a script directly into zsh, the shebang line isn't needed — it's only meaningful when running a script as an executable file. That's why removing it fixed the issue.